### PR TITLE
fix(docs): restore Plots page and nav entry

### DIFF
--- a/docs/plots.md
+++ b/docs/plots.md
@@ -1,0 +1,5 @@
+# Plots
+
+* [動畫列表](assets/plots/anime.html)
+* [付費比例](assets/plots/premium-rate.html)
+* [動畫瘋觀看、評分趨勢](assets/plots/new-anime-trend.html)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_url: !ENV [SITE_URL, https://lee-w.github.io/bahamut_ani_stat/]
 nav:
   - Home: README.md
   - Contributing: contributing.md
+  - Plots: plots.md
   - Data maintenance: data-maintenance.md
   - Schema maintenance: schema-maintenance.md
 theme:


### PR DESCRIPTION
commit d8d3feeb replaced the "Plots: plots.md" nav entry with the new Data/Schema maintenance entries while adding docs/plots.md deletion, which dropped the Plots page from the GitHub Pages navigation.

<!--(Thanks for sending a pull request! Please fill in the following content to let us know better about this change.)-->

## Types of changes
<!--Please remove the types that does not apply to this change-->

- **Bugfix**
- **New feature**
- **Refactoring**
- **Breaking change** (any change that would cause existing functionality to not work as expected)
- **Documentation Update**
- **Other (please describe)**

## Description
<!--Describe what the change is**-->

## Checklist:
- [ ] Add test cases to all the changes you introduce
- [ ] Run `inv style` locally to ensure all linter checks pass
- [ ] Run `inv test` locally to ensure all test cases pass
- [ ] Run `inv secure` locally to ensure no major vulnerability is introduced
- [ ] Update the documentation if necessary

## Steps to Test This Pull Request
<!--
Steps to reproduce the behavior:
1. ...
2. ...
3. ...
-->

## Expected behavior
<!--A clear and concise description of what you expected to happen-->

## Related Issue
<!--If applicable, reference to the issue related to this pull request.-->

## Additional context
<!--Add any other context or screenshots about the pull request here.-->
